### PR TITLE
WIP: Add dependencies for inference to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,13 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: Linux",
     ],
-    python_requires='>=3.6',
+    python_requires=">=3.6",
+    install_requires=[
+        "numpy>=1.19,<2.0",
+        "torch>=1.0,<2.0",
+        "lmdb>=1.0,<2.0",
+        # "tape-proteins>=0.4,<=1.0",
+        "tape-proteins @ git+https://github.com/konstin/tape@patch-1",
+        "scipy>=1.5,<2.0",
+    ],
 )


### PR DESCRIPTION
For integrating CPCProt with bio_embeddings and other downstream tools, it's necessary to specify `install_requires`. I've tried to only specify those dependencies required for inference.

I've marked this a WIP because I'm waiting on https://github.com/songlab-cal/tape/pull/91 being merged.

Could you publish CPCProt to pypi once this is resolved?